### PR TITLE
Removes top-level aliases from snapshot

### DIFF
--- a/src/snapshot-command.ts
+++ b/src/snapshot-command.ts
@@ -14,6 +14,8 @@ export abstract class SnapshotCommand extends Command {
     const commands = this.config.commands
     // Ignore dev plugins
     .filter(command => !devPlugins.includes(command.pluginName ?? ''))
+    // remove aliases that reference themselves
+    .filter(command => !command.aliases.includes(command.id))
     return _.sortBy(commands, 'id')
   }
 


### PR DESCRIPTION
[@W-12085135@](https://gus.my.salesforce.com/apex/ADM_WorkLocator?bugorworknumber=W-12085135)

When running `bin/dev snapshot:generate` aliases were being in the snapshot as a top-level command. This change filters them out. 

Testing instructions.
- Pull branch
- `yarn build`
- `yarn link`
- `cd` into a plugin that has an alias. Example: https://github.com/salesforcecli/plugin-info
- `bin/dev snapshot:generate && yarn format` 
- `git diff`
- Notice that the alias is listed as a top-level command
```diff
+  },
+  {
+    "command": "whatsnew",
+    "plugin": "@salesforce/plugin-info",
+    "flags": ["hook", "json", "loglevel", "version"],
+    "alias": ["whatsnew"]
   }
 ```
- Now link the changes: `yarn link "@oclif/plugin-command-snapshot"`
- `bin/dev snapshot:generate && yarn format` 
- `git diff` 
- No changes 🎉 