### PR TITLE
fix: allow for hyphen in command id

### DIFF
--- a/src/commands/schema/compare.ts
+++ b/src/commands/schema/compare.ts
@@ -8,6 +8,7 @@ import {Schema} from 'ts-json-schema-generator'
 import {SnapshotCommand} from '../../snapshot-command'
 import {getAllFiles, SchemaGenerator, Schemas} from './generate'
 import {bold, cyan, red, underline} from 'chalk'
+import {getKeyNameFromFilename} from '../../util'
 
 export type SchemaComparison = Array<{ op: Operation; path: (string | number)[]; value: any }>
 
@@ -122,7 +123,7 @@ export default class SchemaCompare extends SnapshotCommand {
     } else {
       for (const file of schemaFiles) {
         const schema = JSON.parse(fs.readFileSync(file).toString('utf8')) as Schema
-        const key = path.basename(file.replace(/-/g, ':')).replace('.json', '')
+        const key = path.basename(getKeyNameFromFilename(file))
         if (file.split(path.sep).includes('hooks')) {
           schemas.hooks[key] = schema
         } else {

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,4 +1,3 @@
-import * as path from 'path'
 
 /**
  * Get the file name for a given command ID replacing "-" with "__" and ":" with "-"
@@ -16,7 +15,7 @@ export const getSchemaFileName = (cmdId: string): string => {
  * @returns {string} - command ID
  */
 export const  getKeyNameFromFilename = (file: string): string => {
-  return path.basename(file.replace(/-/g, ':'))
+  return file.replace(/-/g, ':')
   .replace(/__/g, '-')
   .replace('.json', '')
 }

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,0 +1,22 @@
+import * as path from 'path'
+
+/**
+ * Get the file name for a given command ID replacing "-" with "__" and ":" with "-"
+ * @param cmdId - command ID
+ * @returns {string} - file name
+ */
+export const getSchemaFileName = (cmdId: string): string => {
+  const baseName = cmdId.replace(/-/g, '__').replace(/:/g, '-')
+  return `${baseName}.json`
+}
+
+/**
+ * Get the command ID from a given file name replacing "-" with ":" and "__" with "-"
+ * @param file - file name
+ * @returns {string} - command ID
+ */
+export const  getKeyNameFromFilename = (file: string): string => {
+  return path.basename(file.replace(/-/g, ':'))
+  .replace(/__/g, '-')
+  .replace('.json', '')
+}

--- a/test/util.test.ts
+++ b/test/util.test.ts
@@ -1,0 +1,40 @@
+import {expect} from '@oclif/test'
+import {getKeyNameFromFilename} from '../src/util'
+import {getSchemaFileName} from '../lib/util'
+
+describe('util test', () => {
+  describe('getKeyNameFromFilename', () => {
+    it('should return correct command id when only hyphens in file name a-b-c.json', () => {
+      expect(getKeyNameFromFilename('a-b-c.json')).to.equal('a:b:c')
+    })
+    it('should return correct command id when escaped hyphens in file name a-b-c__d.json', () => {
+      expect(getKeyNameFromFilename('a-b-c__d.json')).to.equal('a:b:c-d')
+    })
+    it('should return correct command id when escaped hyphens in file name a__b-c__d.json', () => {
+      expect(getKeyNameFromFilename('a__b-c__d.json')).to.equal('a-b:c-d')
+    })
+    it('should return correct command id when escaped hyphens in file name a-b__c__d.json', () => {
+      expect(getKeyNameFromFilename('a-b__c__d.json')).to.equal('a:b-c-d')
+    })
+    it('should return correct command id when underscore in file name a-b-c_d.json', () => {
+      expect(getKeyNameFromFilename('a-b-c_d.json')).to.equal('a:b:c_d')
+    })
+  })
+  describe('getSchemaFileName', () => {
+    it('should return correct file name when only ":" in command id a:b:c', () => {
+      expect(getSchemaFileName('a:b:c')).to.equal('a-b-c.json')
+    })
+    it('should return correct file name when hyphens in command id a:b:c-d', () => {
+      expect(getSchemaFileName('a:b:c-d')).to.equal('a-b-c__d.json')
+    })
+    it('should return correct file name when hyphens in command id a-b:c-d', () => {
+      expect(getSchemaFileName('a-b:c-d')).to.equal('a__b-c__d.json')
+    })
+    it('should return correct file name when hyphens in command id a:b-c-d', () => {
+      expect(getSchemaFileName('a:b-c-d')).to.equal('a-b__c__d.json')
+    })
+    it('should return correct file name when underscore in command id a:b:c_d', () => {
+      expect(getSchemaFileName('a:b:c_d')).to.equal('a-b-c_d.json')
+    })
+  })
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -3334,15 +3334,10 @@ isarray@^1.0.0, isarray@~1.0.0:
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-1.0.0.tgz#bb935d48582cba168c06834957a54a3e07124f11"
   integrity sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=
 
-isbinaryfile@^4.0.10:
+isbinaryfile@^4.0.10, isbinaryfile@^4.0.8:
   version "4.0.10"
   resolved "https://registry.yarnpkg.com/isbinaryfile/-/isbinaryfile-4.0.10.tgz#0c5b5e30c2557a2f06febd37b7322946aaee42b3"
   integrity sha512-iHrqe5shvBUcFbmZq9zOQHBoeOhZJu6RQGrDpBgenUm/Am+F3JM2MgQj+rK3Z601fzrL5gLZWtAPH2OBaSVcyw==
-
-isbinaryfile@^4.0.8:
-  version "4.0.8"
-  resolved "https://registry.yarnpkg.com/isbinaryfile/-/isbinaryfile-4.0.8.tgz#5d34b94865bd4946633ecc78a026fc76c5b11fcf"
-  integrity sha512-53h6XFniq77YdW+spoRrebh0mnmTxRPTlcuIArO57lmMdq4uBKFKaeTjnb92oYWrSn/LVL+LT+Hap2tFQj8V+w==
 
 isexe@^2.0.0:
   version "2.0.0"
@@ -4862,17 +4857,10 @@ run-parallel@^1.1.9:
   dependencies:
     queue-microtask "^1.2.2"
 
-rxjs@^7.0.0:
+rxjs@^7.0.0, rxjs@^7.2.0:
   version "7.8.0"
   resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-7.8.0.tgz#90a938862a82888ff4c7359811a595e14e1e09a4"
   integrity sha512-F2+gxDshqmIub1KdvZkaEfGDwLNpPvk9Fs6LD/MyQxNgMds/WH9OdDDXOmxUZpME+iSK3rQCctkL0DYyytUqMg==
-  dependencies:
-    tslib "^2.1.0"
-
-rxjs@^7.2.0:
-  version "7.5.4"
-  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-7.5.4.tgz#3d6bd407e6b7ce9a123e76b1e770dc5761aa368d"
-  integrity sha512-h5M3Hk78r6wAheJF0a5YahB1yRQKCsZ4MsGdZ5O9ETbVtjPcScGfrMmoOq7EBsCRzd4BDkvDJ7ogP8Sz5tTFiQ==
   dependencies:
     tslib "^2.1.0"
 


### PR DESCRIPTION
Fixes issue when a command id contains a hyphen when creating and loading schema json files.

command id `a:b:c-d` produces schema file `a-b-c-d.json`

When reading the schema file and calculating command id results in id of `a:b:c:d` when breaks schema compare

Changed filename to use `__` as an escaped hyphen for occurrences of hyphen found in command id

For command id `a:b:c-d` the file name is now `a-b-c__d.json`

When loading the schema file the command id calculation now handles the escaped hyphens from the file and reliably calculates the original command id.